### PR TITLE
Added links to Circuits Up, Will Scala, and Remark

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ If the course has a public facing side, you may include that too. However, pleas
 * Michael Hilton - CMU courses: [[Software Engineering for Startups]](https://github.com/CMU-17-356/cmu-17-356.github.io)
 * https://cs.brynmawr.edu/gxk2013/
 * https://ucsd-cse131-s18.github.io/
-* ...
+* Will Billingsley - Circuits up: [Public](https://theintelligentbook.com/circuitsup/), [GitHub](https://github.com/theIntelligentBook/circuitsup). Will Scala: [Public](https://theintelligentbook.com/willscala/), [GitHub](https://github.com/theIntelligentBook/willscala) 
 
 
 # Formats
@@ -26,3 +26,4 @@ If the course has a public facing side, you may include that too. However, pleas
 ## Slide Decks
 
 * https://gitpitch.com/ (Markdown-based)
+* https://remarkjs.com/ (Markdown-based)


### PR DESCRIPTION
Circuits Up is a set of outreach materials that a colleague has also used as the first four practicals for ICT101 From Logic to Data Processing at UNE.

Will Scala is an experiment in taking the public links from the Echo360 recordings of my Scala course (COSC250 Programming Paradigms) and using them to build a quick-and-dirty public site, in the style of a static site generator (but using the same toolkit as for more interactive outreach materials)

Remark.js is by Ole Petter Bang. It generates slides from Markdown files, and I use it on-campus extensively. Example in my Scala course here (not yet in Will Scala, but soon): http://turing.une.edu.au/~cosc250/lectures/cosc250/lecture.html?IntroScala.md#1